### PR TITLE
Rebranding bt-group -> braintec

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -298,6 +298,10 @@ def gen_addon_readme(
     existing README.rst with content generated from the template,
     fragments (DESCRIPTION.rst, USAGE.rst, etc) and the addon manifest.
     """
+
+    if org_name == 'braintec':
+        org_name = 'brain-tec'
+
     addons = []
     if addons_dir:
         addons.extend(find_addons(addons_dir))

--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -74,21 +74,19 @@ Maintainers
 ~~~~~~~~~~~
 {%- if org_name == 'brain-tec' %}
 
-This module is maintained by bt-group.
+This module is maintained by braintec.
 
-.. image:: https://raw.githubusercontent.com/brain-tec/static/master/img/bt_logo_readme.png
-   :alt: bt-group
+.. image:: https://raw.githubusercontent.com/brain-tec/static/master/img/braintec_logo_readme.png
+   :alt: braintec
    :width: 150px
-   :target: https://www.braintec-group.com/en-us
+   :target: https://braintec.com
 
-bt-group is a is an independent international software and consulting company considered as one of the
-best Odoo partners worldwide, being already awarded several times as Best Odoo Partner in Europe.
+As Odoo Gold Partner and Best Partner Europe 2016, 2020, 2021, we develop business software solutions that are
+high-value and efficient.
 
-Since its founding in 2000, they have supported small to large companies with
-the introduction and implementation of business software projects from their locations
-in Switzerland, Germany, Austria and Spain.
-
-Their goal is the commitment to a more efficient daily business routine in SMEs.
+Our 70 highly qualified employees are represented at nine locations in Switzerland, Germany, Austria and Spain.
+With our experience, methodology and the most certified Odoo experts worldwide, we have successfully supported
+over 300 companies in their digital transformation since 2000.
 {%- endif %}
 
 {%- if org_name == 'OCA' %}


### PR DESCRIPTION
We need to use the org-name braintec (`--org-name braintec`) from now on.

Examples of the new readme generation:

- README.rst
  - https://github.com/brain-tec/bt-hr/blob/15.0.rebranding_bt_time_mgmt/bt_time_mgmt/README.rst
- index.html
![2022-07-15_15:31:19](https://user-images.githubusercontent.com/10939126/179233222-af2cff3b-75d3-4d95-8798-79794778e92c.png)

