### PR TITLE
Fixing DeprecationWarning: 'U' mode is deprecated with io.open(fragme…

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -187,7 +187,7 @@ def gen_one_addon_readme(
             addon_dir, FRAGMENTS_DIR, fragment_name + '.rst',
         )
         if os.path.exists(fragment_filename):
-            with io.open(fragment_filename, 'rU', encoding='utf8') as f:
+            with io.open(fragment_filename, 'r', encoding='utf8') as f:
                 fragment = generate_fragment(
                     org_name, repo_name, branch, addon_name, f)
                 if fragment:
@@ -223,7 +223,7 @@ def gen_one_addon_readme(
         os.path.join(os.path.dirname(__file__), 'gen_addon_readme.template')
     readme_filename = \
         os.path.join(addon_dir, 'README.rst')
-    with io.open(template_filename, 'rU', encoding='utf8') as tf:
+    with io.open(template_filename, 'r', encoding='utf8') as tf:
         template = Template(tf.read())
     with io.open(readme_filename, 'w', encoding='utf8') as rf:
         rf.write(template.render(


### PR DESCRIPTION
…nt_filename, 'rU', encoding='utf8') as f

Solved it just by removing the 'U' parameter, which is deprecated in newer versions of Python.
https://stackoverflow.com/questions/56791545/what-is-the-non-deprecated-version-of-open-u-mode

### Milestone (Odoo version)
- 

### Module(s)
- 

### Fixes / new features
- 
