### PR TITLE
Restore ending new line of README.rst 

### DIFF
--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -138,3 +138,4 @@ You are welcome to contribute. To learn how please visit https://odoo-community.
 You are welcome to contribute.
 
 {%- endif %}
+


### PR DESCRIPTION
Since some days ago we've been receiving this warning when running `bt test code-quality`:

`[W7908(missing-newline-extrafiles), ]  Missing newline`

It's because the template file for our readme is missing the very last end of line, at the end of the file. It was removed because of https://github.com/brain-tec/maintainer-tools/pull/67, probably because of a missconfiguration of PyCharm, set up to remove trailing blank lines at the end of each saved file.

The setting is in "File" > "Settings" > "Editor" > "General" > "Remove trailing blank lines at the end of save files", and the DEV making the aforementioned pull probably had it activated.
