### PR TITLE
Use Relative Images path

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -198,15 +198,15 @@ def generate_fragment(org_name, repo_name, branch, addon_name, file):
             continue
         path = mo.group('path')
 
-        if path.startswith('http'):
+        #if path.startswith('http'):
             # It is already an absolute path
-            continue
-        else:
+        #    continue
+        #else:
             # remove '../' if exists that make the fragment working
             # on github interface, in the 'readme' subfolder
-            relative_path = path.replace('../', '')
-            fragment_lines[index] = fragment_line.replace(
-                path, urljoin(module_url, relative_path))
+        #    relative_path = path.replace('../', '')
+        #    fragment_lines[index] = fragment_line.replace(
+        #        path, urljoin(module_url, relative_path))
     fragment = ''.join(fragment_lines)
 
     # ensure that there is a new empty line at the end of the fragment


### PR DESCRIPTION
* Like that, we can see the images in the Readme.rst files. In the index, we cannot see them, but we could not either because our repos are private and a token is needed in the url.
* As discussed, we could store the images in a public repository for some repos, but this is a temporary solution till it is decided.

### Milestone (Odoo version)
- 

### Module(s)
- 

### Fixes / new features
- 
